### PR TITLE
增加Server对OPTIONS方式的请求处理

### DIFF
--- a/core/router.js
+++ b/core/router.js
@@ -33,6 +33,24 @@ const routers = [
         res.end()
       })
     }
+  },
+  {
+    path: '/testDownload',
+    method: 'GET',
+    callback (req, res) {
+      res.writeHeader(200, {'Content-Type': 'application/octet-stream;charset=UTF-8', 'Content-Disposition': 'attachment;filename=123123123'})
+      res.write('123123123')
+      res.end()
+    }
+  },
+  {
+    path: '/upload',
+    method: 'POST',
+    callback (req, res) {
+      res.writeHeader(200, {'Content-Type': 'application/json;charset=UTF-8'})
+      res.write(JSON.stringify({data: '长传成功'}))
+      res.end()
+    }
   }
 ]
 module.exports = {

--- a/core/server.js
+++ b/core/server.js
@@ -35,6 +35,10 @@ module.exports = class Server {
           case 'GET':
             this.queue.get[url].call(null, req, res, param)
             break
+          case 'OPTIONS':
+            res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS')
+            res.end()
+            break
           /* for other methods */
         }
       }


### PR DESCRIPTION
处理OPTIONS时，添加一个`Access-Control-Allow-Methods`的请求头，值为`POST, GET, OPTIONS`